### PR TITLE
use env for better os compat

### DIFF
--- a/gh-tidy
+++ b/gh-tidy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 help() {


### PR DESCRIPTION
Not all operating systems keep their bash in the same place, so this improves compat with for instance nixos. 👽