### PR TITLE
fix: checking for updates

### DIFF
--- a/gh-tidy
+++ b/gh-tidy
@@ -193,14 +193,14 @@ case "${unameOut}" in
 esac
 if [ "${machine}" == "Mac" ]; then
     # https://stackoverflow.com/questions/11337041/force-line-buffering-of-stdout-in-a-pipeline/11337109#11337109
-    script -q /dev/null gh extension upgrade HaywardMorihara/gh-tidy --dry-run | grep "Would have upgraded extension" && \
+    script -q /dev/null gh extension upgrade HaywardMorihara/gh-tidy --dry-run | grep "would have upgraded from" && \
     echo "Upgrade by running: " && \
     yellow "    gh extension upgrade HaywardMorihara/gh-tidy" \
     || green "No available updates found"
 fi
 if [ "${machine}" == "Linux" ]; then
     # https://stackoverflow.com/questions/11337041/force-line-buffering-of-stdout-in-a-pipeline/11337109#11337109
-    script -q -c "gh extension upgrade HaywardMorihara/gh-tidy --dry-run" /dev/null | grep "Would have upgraded extension" && \
+    script -q -c "gh extension upgrade HaywardMorihara/gh-tidy --dry-run" /dev/null | grep "would have upgraded from" && \
     echo "Upgrade by running: " && \
     yellow "    gh extension upgrade HaywardMorihara/gh-tidy" \
     || green "No available updates found"


### PR DESCRIPTION
The GitHub CLI slightly altered how it checks extensions for upgrades. The new way will still log that the extension is up-to-date, but will _always_ log "✓ Would have upgraded extension" when the --dry-run flag is enabled.

See https://github.com/cli/cli/commit/88cae9f5be67989be191cd4a1fe043ddbeafe629

All we need is to slightly alter the message text we're checking for in order to get this working again.