### PR TITLE
Enable an option for setting the repo trunk branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ gh tidy
 ```
 and it will checkout master/main, pull the latest, and clean up branches for you (with your permission, of course).
 
+If your repo doesn't _have_ a master/main branch, you can specify your trunk branch with the `--trunk <branchname>` parameter
+
 ## Troubleshooting
 If you get an error such as:
 ```sh

--- a/gh-tidy
+++ b/gh-tidy
@@ -26,7 +26,7 @@ EOF
 # TODO I don't _love_ how there's a mix of additive/subtractive flags...
 REBASE_ALL=false
 SKIP_GC=false
-TRUNK_BRANCH=''
+TRUNK_BRANCH_PARAM=''
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -42,7 +42,7 @@ while [ $# -gt 0 ]; do
     ;;
   --trunk)
     shift
-    TRUNK_BRANCH=$1
+    TRUNK_BRANCH_PARAM=$1
     ;;
   esac
   shift
@@ -89,14 +89,14 @@ else
     green "No staged nor unstaged commits found."
 fi
 
-function set_master_or_main() {
-    if [[ ! -z ${TRUNK_BRANCH} ]]; then
-        local user_trunk_branch=$(git branch --list ${TRUNK_BRANCH})
+function set_trunk_branch() {
+    if [[ ! -z ${TRUNK_BRANCH_PARAM} ]]; then
+        local user_trunk_branch=$(git branch --list ${TRUNK_BRANCH_PARAM})
         if [[ ! -z ${user_trunk_branch} ]]; then
-            trunk_branch=${TRUNK_BRANCH}
+            trunk_branch=${TRUNK_BRANCH_PARAM}
             return
         else
-            yellow "WARNING: Specified trunk branch '${TRUNK_BRANCH}' not found - defaulting to 'master' or 'main'"
+            yellow "WARNING: Specified trunk branch '${TRUNK_BRANCH_PARAM}' not found - defaulting to 'master' or 'main'"
         fi
     fi
 
@@ -109,11 +109,13 @@ function set_master_or_main() {
     local main_branch=$(git branch --list main)
     if [[ ! -z ${main_branch} ]]; then
         trunk_branch="main"
+        return
     fi
 
     red "No trunk branch found; specify one with the --trunk <branch-name> flag"
 }
-set_master_or_main
+
+set_trunk_branch
 echo
 cyan "Determined '$trunk_branch' as the trunk branch"
 

--- a/gh-tidy
+++ b/gh-tidy
@@ -110,6 +110,8 @@ function set_master_or_main() {
     if [[ ! -z ${main_branch} ]]; then
         trunk_branch="main"
     fi
+
+    red "No trunk branch found; specify one with the --trunk <branch-name> flag"
 }
 set_master_or_main
 echo

--- a/gh-tidy
+++ b/gh-tidy
@@ -18,12 +18,15 @@ Options:
         Rebases all your local branches to the latest master.
     --skip-gc
 	Skips the 'git gc' step (which executes by default)
+    --trunk branch-name
+    Specifies the trunk branch to use (default: 'master' or 'main' if 'master' doesn't exist)
 EOF
 }
 
 # TODO I don't _love_ how there's a mix of additive/subtractive flags...
 REBASE_ALL=false
 SKIP_GC=false
+TRUNK_BRANCH=''
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -36,6 +39,10 @@ while [ $# -gt 0 ]; do
     ;;
   --skip-gc)
     SKIP_GC=true
+    ;;
+  --trunk)
+    shift
+    TRUNK_BRANCH=$1
     ;;
   esac
   shift
@@ -83,6 +90,16 @@ else
 fi
 
 function set_master_or_main() {
+    if [[ ! -z ${TRUNK_BRANCH} ]]; then
+        local user_trunk_branch=$(git branch --list ${TRUNK_BRANCH})
+        if [[ ! -z ${user_trunk_branch} ]]; then
+            trunk_branch=${TRUNK_BRANCH}
+            return
+        else
+            yellow "WARNING: Specified trunk branch '${TRUNK_BRANCH}' not found - defaulting to 'master' or 'main'"
+        fi
+    fi
+
     local master_branch=$(git branch --list master)
     if [[ ! -z ${master_branch} ]]; then
         trunk_branch="master"


### PR DESCRIPTION
This was the simplest thing I could think of to let someone specify the trunk branch.  If it doesn't exist, it'll just use the defaults as it did before.

Hopefully addresses https://github.com/HaywardMorihara/gh-tidy/issues/46