### PR TITLE
fix pulling trunk branch

### DIFF
--- a/gh-tidy
+++ b/gh-tidy
@@ -129,7 +129,7 @@ if [[ -z $GH_TIDY_DEV_MODE ]]; then
     trunk_remote="$(git config --get "branch.$(git branch --show-current).remote" || echo "")"
     if [[ -z "$trunk_remote" ]]; then
         # when the trunk branch doesn't have a remote set, try pulling from origin
-        git pull origin $trunk_branch
+        git pull origin "$trunk_branch"
     else
         git pull
     fi


### PR DESCRIPTION
The default remote is not always called "origin".

I often pull the master branch from an "upstream" remote (original project) and make feature branches that are pushed to "origin" (private fork).

This PR fixes the logic so that the trunk branch is pulled from the correct remote where possible, with a fallback to "origin".