### PR TITLE
feat: add git fetch --prune before pulling trunk branch

### DIFF
--- a/gh-tidy
+++ b/gh-tidy
@@ -126,6 +126,8 @@ echo
 cyan "Switching to $trunk_branch to pull the latest..."
 if [[ -z $GH_TIDY_DEV_MODE ]]; then
     git checkout $trunk_branch
+    cyan "Fetching and pruning remote branches..."
+    git fetch --prune
     trunk_remote="$(git config --get "branch.$(git branch --show-current).remote" || echo "")"
     if [[ -z "$trunk_remote" ]]; then
         # when the trunk branch doesn't have a remote set, try pulling from origin


### PR DESCRIPTION
This ensures remote-tracking branches that no longer exist on the remote are cleaned up during the tidy process