### PR TITLE
Add a new flag to disable git fetch --prune from running automatically

### DIFF
--- a/gh-tidy
+++ b/gh-tidy
@@ -18,6 +18,8 @@ Options:
         Rebases all your local branches to the latest master.
     --skip-gc
 	Skips the 'git gc' step (which executes by default)
+    --skip-prune
+	Skips the 'git fetch --prune' step (which executes by default)
     --trunk branch-name
     Specifies the trunk branch to use (default: 'master' or 'main' if 'master' doesn't exist)
 EOF
@@ -26,6 +28,7 @@ EOF
 # TODO I don't _love_ how there's a mix of additive/subtractive flags...
 REBASE_ALL=false
 SKIP_GC=false
+SKIP_PRUNE=false
 TRUNK_BRANCH_PARAM=''
 
 while [ $# -gt 0 ]; do
@@ -39,6 +42,9 @@ while [ $# -gt 0 ]; do
     ;;
   --skip-gc)
     SKIP_GC=true
+    ;;
+  --skip-prune)
+    SKIP_PRUNE=true
     ;;
   --trunk)
     shift
@@ -126,8 +132,13 @@ echo
 cyan "Switching to $trunk_branch to pull the latest..."
 if [[ -z $GH_TIDY_DEV_MODE ]]; then
     git checkout $trunk_branch
-    cyan "Fetching and pruning remote branches..."
-    git fetch --prune
+    if ! "$SKIP_PRUNE"; then
+        cyan "Fetching and pruning remote branches..."
+        git fetch --prune
+    else
+        cyan "Fetching remote branches (skipping prune)..."
+        git fetch
+    fi
     trunk_remote="$(git config --get "branch.$(git branch --show-current).remote" || echo "")"
     if [[ -z "$trunk_remote" ]]; then
         # when the trunk branch doesn't have a remote set, try pulling from origin

--- a/gh-tidy
+++ b/gh-tidy
@@ -135,9 +135,6 @@ if [[ -z $GH_TIDY_DEV_MODE ]]; then
     if ! "$SKIP_PRUNE"; then
         cyan "Fetching and pruning remote branches..."
         git fetch --prune
-    else
-        cyan "Fetching remote branches (skipping prune)..."
-        git fetch
     fi
     trunk_remote="$(git config --get "branch.$(git branch --show-current).remote" || echo "")"
     if [[ -z "$trunk_remote" ]]; then


### PR DESCRIPTION
`git fetch --prune` can be a very expensive operation in a repo with a lot of remote branches. This adds a flag to skip that, but keeps it as the default.

Closes https://github.com/HaywardMorihara/gh-tidy/issues/53