### PR TITLE
Remove auto-update functionality

### DIFF
--- a/gh-tidy
+++ b/gh-tidy
@@ -23,17 +23,44 @@ Options:
     --skip-update-check
 	Skips checking for updates to gh-tidy extension
     --trunk branch-name
-    Specifies the trunk branch to use (default: 'master' or 'main' if 'master' doesn't exist)
+        Specifies the trunk branch to use (default: 'master' or 'main' if 'master' doesn't exist)
+
+Environment Variables:
+    GH_TIDY_REBASE_ALL      Set to 'true' to rebase all branches (same as --rebase-all)
+    GH_TIDY_SKIP_GC         Set to 'true' to skip git gc (same as --skip-gc)
+    GH_TIDY_SKIP_PRUNE      Set to 'true' to skip git fetch --prune (same as --skip-prune)
+    GH_TIDY_SKIP_UPDATE_CHECK  Set to 'true' to skip update check (same as --skip-update-check)
+    GH_TIDY_TRUNK_BRANCH    Set trunk branch name (same as --trunk)
+
+Note: CLI flags override environment variables. Boolean values accept: 1/true/yes/on or 0/false/no/off
 EOF
 }
 
-# TODO I don't _love_ how there's a mix of additive/subtractive flags...
-REBASE_ALL=false
-SKIP_GC=false
-SKIP_PRUNE=false
-SKIP_UPDATE_CHECK=false
-TRUNK_BRANCH_PARAM=''
+# Helper function to convert string values to boolean
+to_bool() {
+  local val="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$val" in
+    1|true|yes|on) echo true ;;
+    0|false|no|off|"") echo false ;;
+    *) echo false ;;
+  esac
+}
 
+# Default values
+REBASE_ALL_DEFAULT=false
+SKIP_GC_DEFAULT=false
+SKIP_PRUNE_DEFAULT=false
+SKIP_UPDATE_CHECK_DEFAULT=false
+TRUNK_BRANCH_DEFAULT=""
+
+# Initialize from environment variables if set, otherwise use defaults
+REBASE_ALL=$(to_bool "${GH_TIDY_REBASE_ALL:-$REBASE_ALL_DEFAULT}")
+SKIP_GC=$(to_bool "${GH_TIDY_SKIP_GC:-$SKIP_GC_DEFAULT}")
+SKIP_PRUNE=$(to_bool "${GH_TIDY_SKIP_PRUNE:-$SKIP_PRUNE_DEFAULT}")
+SKIP_UPDATE_CHECK=$(to_bool "${GH_TIDY_SKIP_UPDATE_CHECK:-$SKIP_UPDATE_CHECK_DEFAULT}")
+TRUNK_BRANCH_PARAM="${GH_TIDY_TRUNK_BRANCH:-$TRUNK_BRANCH_DEFAULT}"
+
+# Parse command line arguments (these override environment variables)
 while [ $# -gt 0 ]; do
   case "$1" in
   -h|--help)

--- a/gh-tidy
+++ b/gh-tidy
@@ -20,6 +20,8 @@ Options:
 	Skips the 'git gc' step (which executes by default)
     --skip-prune
 	Skips the 'git fetch --prune' step (which executes by default)
+    --skip-update-check
+	Skips checking for updates to gh-tidy extension
     --trunk branch-name
     Specifies the trunk branch to use (default: 'master' or 'main' if 'master' doesn't exist)
 EOF
@@ -29,6 +31,7 @@ EOF
 REBASE_ALL=false
 SKIP_GC=false
 SKIP_PRUNE=false
+SKIP_UPDATE_CHECK=false
 TRUNK_BRANCH_PARAM=''
 
 while [ $# -gt 0 ]; do
@@ -45,6 +48,9 @@ while [ $# -gt 0 ]; do
     ;;
   --skip-prune)
     SKIP_PRUNE=true
+    ;;
+  --skip-update-check)
+    SKIP_UPDATE_CHECK=true
     ;;
   --trunk)
     shift
@@ -228,6 +234,33 @@ if "$REBASE_ALL"; then
     git checkout "${trunk_branch}"
     echo
     green "Finished rebasing!"
+fi
+
+if ! "$SKIP_UPDATE_CHECK"; then
+    echo
+    cyan "Checking if there are updates available for 'gh-tidy'..."
+    # https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux
+    unameOut="$(uname -s)"
+    case "${unameOut}" in
+        Linux*)     machine=Linux;;
+        Darwin*)    machine=Mac;;
+        CYGWIN*)    machine=Cygwin;;
+        *)          machine="UNSUPPORTED"
+    esac
+    if [ "${machine}" == "Mac" ]; then
+        # https://stackoverflow.com/questions/11337041/force-line-buffering-of-stdout-in-a-pipeline/11337109#11337109
+        script -q /dev/null gh extension upgrade HaywardMorihara/gh-tidy --dry-run | grep "would have upgraded from" && \
+        echo "Upgrade by running: " && \
+        yellow "    gh extension upgrade HaywardMorihara/gh-tidy" \
+        || green "No available updates found"
+    fi
+    if [ "${machine}" == "Linux" ]; then
+        # https://stackoverflow.com/questions/11337041/force-line-buffering-of-stdout-in-a-pipeline/11337109#11337109
+        script -q -c "gh extension upgrade HaywardMorihara/gh-tidy --dry-run" /dev/null | grep "would have upgraded from" && \
+        echo "Upgrade by running: " && \
+        yellow "    gh extension upgrade HaywardMorihara/gh-tidy" \
+        || green "No available updates found"
+    fi
 fi
 
 echo

--- a/gh-tidy
+++ b/gh-tidy
@@ -231,32 +231,6 @@ if "$REBASE_ALL"; then
 fi
 
 echo
-cyan "Checking if there are updates available for 'gh-tidy'..."
-# https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux
-unameOut="$(uname -s)"
-case "${unameOut}" in
-    Linux*)     machine=Linux;;
-    Darwin*)    machine=Mac;;
-    CYGWIN*)    machine=Cygwin;;
-    *)          machine="UNSUPPORTED"
-esac
-if [ "${machine}" == "Mac" ]; then
-    # https://stackoverflow.com/questions/11337041/force-line-buffering-of-stdout-in-a-pipeline/11337109#11337109
-    script -q /dev/null gh extension upgrade HaywardMorihara/gh-tidy --dry-run | grep "would have upgraded from" && \
-    echo "Upgrade by running: " && \
-    yellow "    gh extension upgrade HaywardMorihara/gh-tidy" \
-    || green "No available updates found"
-fi
-if [ "${machine}" == "Linux" ]; then
-    # https://stackoverflow.com/questions/11337041/force-line-buffering-of-stdout-in-a-pipeline/11337109#11337109
-    script -q -c "gh extension upgrade HaywardMorihara/gh-tidy --dry-run" /dev/null | grep "would have upgraded from" && \
-    echo "Upgrade by running: " && \
-    yellow "    gh extension upgrade HaywardMorihara/gh-tidy" \
-    || green "No available updates found"
-fi
-
-
-echo
 if (( ${#problem_branches[@]} )); then
     yellow "WARNING: Unable to auto-rebase the following branches:"
     for problem_branch in "${problem_branches[@]}"; do

--- a/gh-tidy
+++ b/gh-tidy
@@ -23,7 +23,7 @@ Options:
     --skip-update-check
 	Skips checking for updates to gh-tidy extension
     --trunk branch-name
-        Specifies the trunk branch to use (default: 'master' or 'main' if 'master' doesn't exist)
+    Specifies the trunk branch to use (default: 'master' or 'main' if 'master' doesn't exist)
 
 Environment Variables:
     GH_TIDY_REBASE_ALL      Set to 'true' to rebase all branches (same as --rebase-all)

--- a/gh-tidy
+++ b/gh-tidy
@@ -26,11 +26,11 @@ Options:
     Specifies the trunk branch to use (default: 'master' or 'main' if 'master' doesn't exist)
 
 Environment Variables:
-    GH_TIDY_REBASE_ALL      Set to 'true' to rebase all branches (same as --rebase-all)
-    GH_TIDY_SKIP_GC         Set to 'true' to skip git gc (same as --skip-gc)
-    GH_TIDY_SKIP_PRUNE      Set to 'true' to skip git fetch --prune (same as --skip-prune)
+    GH_TIDY_REBASE_ALL         Set to 'true' to rebase all branches (same as --rebase-all)
+    GH_TIDY_SKIP_GC            Set to 'true' to skip git gc (same as --skip-gc)
+    GH_TIDY_SKIP_PRUNE         Set to 'true' to skip git fetch --prune (same as --skip-prune)
     GH_TIDY_SKIP_UPDATE_CHECK  Set to 'true' to skip update check (same as --skip-update-check)
-    GH_TIDY_TRUNK_BRANCH    Set trunk branch name (same as --trunk)
+    GH_TIDY_TRUNK_BRANCH       Set trunk branch name (same as --trunk)
 
 Note: CLI flags override environment variables. Boolean values accept: 1/true/yes/on or 0/false/no/off
 EOF


### PR DESCRIPTION
## Summary
- Completely removes the auto-update check functionality from the script
- Eliminates the delay when running the command
- Simplifies the codebase by removing unnecessary update checking logic

## Rationale
GitHub CLI already has built-in functionality to upgrade extensions (`gh extension upgrade`), which external tools like `topgrade` already use. The auto-update check adds unnecessary delay when running the command and duplicates functionality that's better handled by the GitHub CLI itself.