### PR TITLE
fix: run git gc after rebase and handle errors

### DIFF
--- a/gh-tidy
+++ b/gh-tidy
@@ -259,8 +259,11 @@ fi
 if ! "$SKIP_GC"; then
     echo
     cyan "Cleaning unnecessary files & optimizing your local repo..."
-    git gc || true
-    green "Complete!"
+    if git gc; then
+        green "Cleanup complete!"
+    else
+        yellow "WARNING: Cleanup attempted, but 'git gc' failed."
+    fi
 fi
 
 if ! "$SKIP_UPDATE_CHECK"; then

--- a/gh-tidy
+++ b/gh-tidy
@@ -180,13 +180,6 @@ else
     magenta "GH_TIDY_DEV_MODE: Skipping $trunk_branch checkout & update because in GH_TIDY_DEV_MODE"
 fi
 
-if ! "$SKIP_GC"; then
-    echo
-    cyan "Cleaning unnecessary files & optimizing your local repo..."
-    git gc
-    green "Complete!"
-fi
-
 # Function to check if a branch exists locally
 function branch_exists_locally() {
     local branch="$1"
@@ -261,6 +254,13 @@ if "$REBASE_ALL"; then
     git checkout "${trunk_branch}"
     echo
     green "Finished rebasing!"
+fi
+
+if ! "$SKIP_GC"; then
+    echo
+    cyan "Cleaning unnecessary files & optimizing your local repo..."
+    git gc || true
+    green "Complete!"
 fi
 
 if ! "$SKIP_UPDATE_CHECK"; then


### PR DESCRIPTION
Moved the git gc cleanup to occur after the rebase/delete operations and added error handling to prevent script failure if git gc fails.