### PR TITLE
feat: safely remove stale and landed locked worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Runs 'git gc' to clean up unnecessary files & optimize your local repo
 * Checks your local branches for ones that show as merged to master, and asks for your permission to delete them
 * Checks your local branches for ones that have their corresponding pull requests merged, and asks for your permission to delete them
-* Checks for worktrees locked by another program (IDE, editor, sync tool) whose directory is gone, and asks for your permission to unlock & remove them — `git worktree prune` skips locked worktrees, so these otherwise linger forever and keep their branch un-deletable
+* Checks for worktrees locked by another program (IDE, editor, sync tool) whose directory is gone, and asks for your permission to unlock & remove them — `git worktree prune` skips locked worktrees, so these otherwise linger forever and keep their branch un-deletable. The prompt reports whether the worktree's branch was merged on the remote (including squash-merges, via its pull request); removing a worktree never deletes its branch, so an unmerged one is kept and left to the branch-pruning steps
 * If flagged, rebases all your local branches to the latest master
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * Runs 'git gc' to clean up unnecessary files & optimize your local repo
 * Checks your local branches for ones that show as merged to master, and asks for your permission to delete them
 * Checks your local branches for ones that have their corresponding pull requests merged, and asks for your permission to delete them
+* Checks for worktrees locked by another program (IDE, editor, sync tool) whose directory is gone, and asks for your permission to unlock & remove them — `git worktree prune` skips locked worktrees, so these otherwise linger forever and keep their branch un-deletable
 * If flagged, rebases all your local branches to the latest master
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * Runs 'git gc' to clean up unnecessary files & optimize your local repo
 * Checks your local branches for ones that show as merged to master, and asks for your permission to delete them
 * Checks your local branches for ones that have their corresponding pull requests merged, and asks for your permission to delete them
-* Checks for worktrees locked by another program (IDE, editor, sync tool) whose directory is gone, and asks for your permission to unlock & remove them — `git worktree prune` skips locked worktrees, so these otherwise linger forever and keep their branch un-deletable. The prompt reports whether the worktree's branch was merged on the remote (including squash-merges, via its pull request); removing a worktree never deletes its branch, so an unmerged one is kept and left to the branch-pruning steps
+* Checks locked worktrees safely. Existing worktrees are offered for removal only when clean and landed; missing locked worktrees remain an interactive cleanup task. Automatic mode leaves missing, dirty, detached, unlanded, and unverifiable worktrees intact. Removing a worktree never deletes its branch, so later branch-pruning steps decide that separately
 * If flagged, rebases all your local branches to the latest master
 
 ## Installation

--- a/gh-tidy
+++ b/gh-tidy
@@ -243,32 +243,56 @@ function get_worktree_branches() {
 
 # A worktree locked by another program (IDE, editor, backup/sync tool) is excluded
 # from 'git worktree prune', so once its directory is gone it lingers forever and
-# keeps its branch un-deletable.  List those so we can offer to unlock & remove them.
+# keeps its branch un-deletable.  Emit "<path>TAB<branch>" for each of those.
 function get_stale_locked_worktrees() {
   git worktree list --porcelain 2>/dev/null \
-    | awk '
-        /^worktree / { path = substr($0, 10); locked = 0 }
+    | awk -v OFS='\t' '
+        /^worktree / { path = substr($0, 10); branch = ""; locked = 0 }
+        /^branch /   { branch = substr($0, 8); sub("^refs/heads/", "", branch) }
         /^locked/    { locked = 1 }
-        /^$/         { if (locked) print path; path = ""; locked = 0 }
-        END          { if (locked) print path }
+        /^$/         { if (locked) print path, branch; path = ""; branch = ""; locked = 0 }
+        END          { if (locked) print path, branch }
       '
+}
+
+# Has this branch landed on the remote?  Checks a plain merge into trunk first
+# (cheap, offline), then falls back to a merged PR on GitHub to catch squash-merges.
+# Unlike the branch-pruning steps below this isn't limited to --author @me: the
+# question here is "did this land", no matter who opened the PR.
+function branch_is_merged() {
+    local branch="$1"
+    [[ -n "$branch" ]] || return 1
+    if git branch --merged "$trunk_branch" --format='%(refname:short)' | grep -qx "$branch"; then
+        return 0
+    fi
+    [[ -n "$(gh pr list --state merged --limit 1 --search "head:$branch" --json headRefName --jq '.[].headRefName' 2>/dev/null)" ]]
 }
 
 echo
 cyan "Checking for stale worktrees locked by another program..."
-while IFS= read -r worktree_path; do
+while IFS=$'\t' read -r worktree_path worktree_branch; do
     [[ -n "$worktree_path" ]] || continue
     if [[ -d "$worktree_path" ]]; then
         # ponytail: a locked worktree whose directory still exists is presumed in use.
         green "Skipping locked worktree '$worktree_path' (directory still exists)."
         continue
     fi
+    # Removing a worktree never deletes its branch, so this is reported to inform the
+    # choice, not to block it - an unmerged branch survives and is left for the
+    # branch-pruning steps below.
+    if [[ -z "$worktree_branch" ]]; then
+        merge_status="no branch checked out"
+    elif branch_is_merged "$worktree_branch"; then
+        merge_status="branch '$worktree_branch' is merged"
+    else
+        merge_status="branch '$worktree_branch' is NOT merged - it will be kept"
+    fi
     if ! "$AUTO_DELETE_MERGED"; then
-        read -p $'\e[93m'"Worktree ${worktree_path} is locked but its directory is gone - remove it? (y/n) "$'\e[0m' -n 1 -r
+        read -p $'\e[93m'"Worktree ${worktree_path} is locked but its directory is gone (${merge_status}) - remove it? (y/n) "$'\e[0m' -n 1 -r
         echo
         [[ $REPLY =~ ^[Yy]$ ]] || continue
     else
-        yellow "Auto-removing stale locked worktree '${worktree_path}'"
+        yellow "Auto-removing stale locked worktree '${worktree_path}' (${merge_status})"
     fi
     git worktree unlock "$worktree_path" || true
     git worktree remove --force "$worktree_path" || true

--- a/gh-tidy
+++ b/gh-tidy
@@ -255,17 +255,26 @@ function get_stale_locked_worktrees() {
       '
 }
 
-# Has this branch landed on the remote?  Checks a plain merge into trunk first
-# (cheap, offline), then falls back to a merged PR on GitHub to catch squash-merges.
-# Unlike the branch-pruning steps below this isn't limited to --author @me: the
-# question here is "did this land", no matter who opened the PR.
-function branch_is_merged() {
-    local branch="$1"
-    [[ -n "$branch" ]] || return 1
-    if git branch --merged "$trunk_branch" --format='%(refname:short)' | grep -qx "$branch"; then
+function worktree_head_is_merged() {
+    local head="$1"
+    local branch="$2"
+    git merge-base --is-ancestor "$head" "$trunk_branch" && return 0
+    [[ -n "$(gh pr list --state merged --limit 100 --search "head:$branch" --json headRefOid --jq '.[].headRefOid' 2>/dev/null | grep -Fx "$head")" ]]
+}
+
+function remove_locked_worktree() {
+    local path="$1"
+    if ! git worktree unlock "$path"; then
+        red "Unable to unlock locked worktree '$path'."
+        return 1
+    fi
+    if git worktree remove "$path"; then
+        green "Removed locked worktree '$path'."
         return 0
     fi
-    [[ -n "$(gh pr list --state merged --limit 1 --search "head:$branch" --json headRefName --jq '.[].headRefName' 2>/dev/null)" ]]
+    red "Unable to remove locked worktree '$path'; restoring its lock."
+    git worktree lock "$path" || red "Unable to restore lock for '$path'."
+    return 1
 }
 
 # Ask a yes/no question, answering "no" when there's nothing to ask on.  A bare
@@ -290,27 +299,50 @@ cyan "Checking for stale worktrees locked by another program..."
 while IFS=$'\t' read -r -u 3 worktree_path worktree_branch; do
     [[ -n "$worktree_path" ]] || continue
     if [[ -d "$worktree_path" ]]; then
-        # ponytail: a locked worktree whose directory still exists is presumed in use.
-        green "Skipping locked worktree '$worktree_path' (directory still exists)."
+        if [[ -z "$worktree_branch" ]]; then
+            yellow "Keeping locked worktree '$worktree_path' (no branch checked out)."
+            continue
+        fi
+        if ! worktree_branch=$(git -C "$worktree_path" symbolic-ref --quiet --short HEAD); then
+            yellow "Keeping locked worktree '$worktree_path' (detached or unverifiable branch)."
+            continue
+        fi
+        if ! worktree_head=$(git -C "$worktree_path" rev-parse --verify HEAD 2>/dev/null); then
+            yellow "Keeping locked worktree '$worktree_path' (unverifiable HEAD)."
+            continue
+        fi
+        if ! worktree_status=$(git -C "$worktree_path" status --porcelain --untracked-files=all 2>/dev/null); then
+            yellow "Keeping locked worktree '$worktree_path' (unable to inspect status)."
+            continue
+        elif [[ -n "$worktree_status" ]]; then
+            yellow "Keeping locked worktree '$worktree_path' (dirty)."
+            continue
+        fi
+        if ! worktree_head_is_merged "$worktree_head" "$worktree_branch"; then
+            yellow "Keeping locked worktree '$worktree_path' (HEAD is not landed)."
+            continue
+        fi
+        if "$AUTO_DELETE_MERGED"; then
+            yellow "Auto-removing locked worktree '$worktree_path' (clean, landed HEAD)"
+            remove_locked_worktree "$worktree_path" || true
+        elif confirm "Locked worktree ${worktree_path} is clean with a landed HEAD - remove it?"; then
+            remove_locked_worktree "$worktree_path" || true
+        fi
         continue
-    fi
-    # Removing a worktree never deletes its branch, so this is reported to inform the
-    # choice, not to block it - an unmerged branch survives and is left for the
-    # branch-pruning steps below.
-    if [[ -z "$worktree_branch" ]]; then
-        merge_status="no branch checked out"
-    elif branch_is_merged "$worktree_branch"; then
-        merge_status="branch '$worktree_branch' is merged"
-    else
-        merge_status="branch '$worktree_branch' is NOT merged - it will be kept"
     fi
     if "$AUTO_DELETE_MERGED"; then
-        yellow "Auto-removing stale locked worktree '${worktree_path}' (${merge_status})"
-    elif ! confirm "Worktree ${worktree_path} is locked but its directory is gone (${merge_status}) - remove it?"; then
+        yellow "Skipping locked worktree '$worktree_path' (directory is gone; contents cannot be inspected)."
         continue
     fi
-    git worktree unlock "$worktree_path" || true
-    git worktree remove --force "$worktree_path" || true
+    if [[ -z "$worktree_branch" ]]; then
+        merge_status="no branch checked out"
+    else
+        merge_status="branch '$worktree_branch' cannot be verified because its directory is gone"
+    fi
+    if ! confirm "Worktree ${worktree_path} is locked but its directory is gone (${merge_status}) - remove it?"; then
+        continue
+    fi
+    remove_locked_worktree "$worktree_path" || true
 done 3< <(get_stale_locked_worktrees)
 green "Complete!"
 

--- a/gh-tidy
+++ b/gh-tidy
@@ -298,6 +298,23 @@ function confirm() {
     [[ $REPLY =~ ^[Yy]$ ]]
 }
 
+# Removing a worktree leaves its branch behind.  We already proved the branch's
+# HEAD landed to justify the removal, so delete it here rather than let the branch
+# passes below re-derive it - 'git branch --merged' misses a squash merge, and the
+# pull request pass only looks at branches you authored.
+function delete_landed_branch() {
+    local branch="$1"
+    [[ -n "$branch" ]] || return 0
+    branch_exists_locally "$branch" || return 0
+    [[ "$branch" != "$trunk_branch" ]] || return 0
+    if "$AUTO_DELETE_MERGED"; then
+        yellow "Auto-deleting branch '${branch}' (worktree removed, HEAD landed)"
+        git branch -D "$branch" || true
+    elif confirm "Branch ${branch} is landed and its worktree is gone - delete it?"; then
+        git branch -D "$branch" || true
+    fi
+}
+
 echo
 cyan "Checking for stale worktrees locked by another program..."
 # Fed on fd 3, not stdin: a plain '< <(...)' would make the worktree list the loop's
@@ -336,9 +353,9 @@ while IFS=$'\t' read -r -u 3 worktree_path worktree_branch; do
         fi
         if "$AUTO_DELETE_MERGED"; then
             yellow "Auto-removing locked worktree '$worktree_path' (clean, landed HEAD)"
-            remove_locked_worktree "$worktree_path" || true
+            { remove_locked_worktree "$worktree_path" && delete_landed_branch "$worktree_branch"; } || true
         elif confirm "Locked worktree ${worktree_path} is clean with a landed HEAD - remove it?"; then
-            remove_locked_worktree "$worktree_path" || true
+            { remove_locked_worktree "$worktree_path" && delete_landed_branch "$worktree_branch"; } || true
         fi
         continue
     fi

--- a/gh-tidy
+++ b/gh-tidy
@@ -258,7 +258,7 @@ function get_stale_locked_worktrees() {
 function worktree_head_is_merged() {
     local head="$1"
     git merge-base --is-ancestor "$head" "$trunk_branch" && return 0
-    [[ -n "$(gh pr list --state merged --limit 1 --search "$head" --json headRefOid --jq '.[].headRefOid' 2>/dev/null | grep -Fx "$head")" ]]
+    [[ -n "$(gh api --paginate "repos/{owner}/{repo}/commits/$head/pulls" --jq ".[] | select(.merged_at != null and .head.sha == \"$head\") | .head.sha" 2>/dev/null | grep -Fx "$head")" ]]
 }
 
 function remove_locked_worktree() {

--- a/gh-tidy
+++ b/gh-tidy
@@ -259,7 +259,7 @@ function worktree_head_is_merged() {
     local head="$1"
     local branch="$2"
     git merge-base --is-ancestor "$head" "$trunk_branch" && return 0
-    [[ -n "$(gh pr list --state merged --limit 100 --search "head:$branch" --json headRefOid --jq '.[].headRefOid' 2>/dev/null | grep -Fx "$head")" ]]
+    [[ -n "$(gh pr list --state merged --limit 10000 --search "head:$branch" --json headRefOid --jq '.[].headRefOid' 2>/dev/null | grep -Fx "$head")" ]]
 }
 
 function remove_locked_worktree() {

--- a/gh-tidy
+++ b/gh-tidy
@@ -268,6 +268,20 @@ function branch_is_merged() {
     [[ -n "$(gh pr list --state merged --limit 1 --search "head:$branch" --json headRefName --jq '.[].headRefName' 2>/dev/null)" ]]
 }
 
+# Ask a yes/no question, answering "no" when there's nothing to ask on.  A bare
+# 'read' with no terminal returns non-zero at EOF, which under 'set -e' takes the
+# whole script down mid-run - so check for a terminal rather than prompting blind.
+function confirm() {
+    local prompt="$1"
+    if [[ ! -t 0 ]]; then
+        yellow "Not interactive, skipping (use --auto-delete-merged): ${prompt}"
+        return 1
+    fi
+    read -p $'\e[93m'"${prompt} (y/n) "$'\e[0m' -n 1 -r
+    echo
+    [[ $REPLY =~ ^[Yy]$ ]]
+}
+
 echo
 cyan "Checking for stale worktrees locked by another program..."
 # Fed on fd 3, not stdin: a plain '< <(...)' would make the worktree list the loop's
@@ -292,15 +306,8 @@ while IFS=$'\t' read -r -u 3 worktree_path worktree_branch; do
     fi
     if "$AUTO_DELETE_MERGED"; then
         yellow "Auto-removing stale locked worktree '${worktree_path}' (${merge_status})"
-    elif [[ ! -t 0 ]]; then
-        # No terminal to prompt on - 'read' would hit EOF and take the whole script
-        # down under 'set -e'.  Leave the worktree alone and say why.
-        yellow "Skipping stale locked worktree '${worktree_path}' - not interactive (use --auto-delete-merged)."
+    elif ! confirm "Worktree ${worktree_path} is locked but its directory is gone (${merge_status}) - remove it?"; then
         continue
-    else
-        read -p $'\e[93m'"Worktree ${worktree_path} is locked but its directory is gone (${merge_status}) - remove it? (y/n) "$'\e[0m' -n 1 -r
-        echo
-        [[ $REPLY =~ ^[Yy]$ ]] || continue
     fi
     git worktree unlock "$worktree_path" || true
     git worktree remove --force "$worktree_path" || true
@@ -337,9 +344,7 @@ for branch in $(git branch --merged "$trunk_branch" --format='%(refname:short)')
             yellow "Auto-deleting branch '${branch}' (merged into $trunk_branch)"
             git branch -D "${branch}" || true
         else
-            read -p $'\e[93m'"Branch ${branch} is merged into $trunk_branch - delete it? (y/n) "$'\e[0m' -n 1 -r
-            echo
-            if [[ $REPLY =~ ^[Yy]$ ]]; then
+            if confirm "Branch ${branch} is merged into $trunk_branch - delete it?"; then
                 git branch -D "${branch}" || true
             fi
         fi
@@ -362,9 +367,7 @@ for branch in $(git branch --format='%(refname:short)'); do
                 yellow "Auto-deleting branch '${merged_branch}' (PR merged on GitHub)"
                 git branch -D "${merged_branch}" || true
             else
-                read -p $'\e[93m'"Branch ${merged_branch} has been merged - delete it? (y/n) "$'\e[0m' -n 1 -r
-                echo
-                if [[ $REPLY =~ ^[Yy]$ ]]; then
+                if confirm "Branch ${merged_branch} has been merged - delete it?"; then
                     git branch -D "${merged_branch}" || true
                 fi
             fi

--- a/gh-tidy
+++ b/gh-tidy
@@ -257,9 +257,8 @@ function get_stale_locked_worktrees() {
 
 function worktree_head_is_merged() {
     local head="$1"
-    local branch="$2"
     git merge-base --is-ancestor "$head" "$trunk_branch" && return 0
-    [[ -n "$(gh pr list --state merged --limit 10000 --search "head:$branch" --json headRefOid --jq '.[].headRefOid' 2>/dev/null | grep -Fx "$head")" ]]
+    [[ -n "$(gh pr list --state merged --limit 1 --search "$head" --json headRefOid --jq '.[].headRefOid' 2>/dev/null | grep -Fx "$head")" ]]
 }
 
 function remove_locked_worktree() {
@@ -318,7 +317,7 @@ while IFS=$'\t' read -r -u 3 worktree_path worktree_branch; do
             yellow "Keeping locked worktree '$worktree_path' (dirty)."
             continue
         fi
-        if ! worktree_head_is_merged "$worktree_head" "$worktree_branch"; then
+        if ! worktree_head_is_merged "$worktree_head"; then
             yellow "Keeping locked worktree '$worktree_path' (HEAD is not landed)."
             continue
         fi

--- a/gh-tidy
+++ b/gh-tidy
@@ -270,7 +270,10 @@ function branch_is_merged() {
 
 echo
 cyan "Checking for stale worktrees locked by another program..."
-while IFS=$'\t' read -r worktree_path worktree_branch; do
+# Fed on fd 3, not stdin: a plain '< <(...)' would make the worktree list the loop's
+# stdin, so the 'read -p' prompt below would silently eat list entries instead of
+# asking the user.
+while IFS=$'\t' read -r -u 3 worktree_path worktree_branch; do
     [[ -n "$worktree_path" ]] || continue
     if [[ -d "$worktree_path" ]]; then
         # ponytail: a locked worktree whose directory still exists is presumed in use.
@@ -287,16 +290,21 @@ while IFS=$'\t' read -r worktree_path worktree_branch; do
     else
         merge_status="branch '$worktree_branch' is NOT merged - it will be kept"
     fi
-    if ! "$AUTO_DELETE_MERGED"; then
+    if "$AUTO_DELETE_MERGED"; then
+        yellow "Auto-removing stale locked worktree '${worktree_path}' (${merge_status})"
+    elif [[ ! -t 0 ]]; then
+        # No terminal to prompt on - 'read' would hit EOF and take the whole script
+        # down under 'set -e'.  Leave the worktree alone and say why.
+        yellow "Skipping stale locked worktree '${worktree_path}' - not interactive (use --auto-delete-merged)."
+        continue
+    else
         read -p $'\e[93m'"Worktree ${worktree_path} is locked but its directory is gone (${merge_status}) - remove it? (y/n) "$'\e[0m' -n 1 -r
         echo
         [[ $REPLY =~ ^[Yy]$ ]] || continue
-    else
-        yellow "Auto-removing stale locked worktree '${worktree_path}' (${merge_status})"
     fi
     git worktree unlock "$worktree_path" || true
     git worktree remove --force "$worktree_path" || true
-done < <(get_stale_locked_worktrees)
+done 3< <(get_stale_locked_worktrees)
 green "Complete!"
 
 worktree_branches=$(get_worktree_branches)

--- a/gh-tidy
+++ b/gh-tidy
@@ -266,11 +266,13 @@ function get_prunable_worktrees() {
 # Has this commit landed on the trunk?  Returns 0 yes, 1 no, 2 couldn't tell.
 # The GitHub lookup is by head commit, not branch name or author, so it also sees
 # squash merges and pull requests opened by someone other than you.
+github_host=$(gh repo view --json url --jq '.url | capture("^https?://(?<host>[^/]+)").host' 2>/dev/null || true)
 function head_is_merged() {
     local head="$1"
     git merge-base --is-ancestor "$head" "$trunk_branch" && return 0
-    local merged_heads
-    if ! merged_heads=$(gh api --paginate "repos/{owner}/{repo}/commits/$head/pulls" --jq ".[] | select(.merged_at != null and .head.sha == \"$head\") | .head.sha" 2>/dev/null); then
+    local merged_heads hostname=()
+    [[ -z "$github_host" ]] || hostname=(--hostname "$github_host")
+    if ! merged_heads=$(gh api "${hostname[@]}" --paginate "repos/{owner}/{repo}/commits/$head/pulls" --jq ".[] | select(.merged_at != null and .head.sha == \"$head\") | .head.sha" 2>/dev/null); then
         return 2
     fi
     printf '%s\n' "$merged_heads" | grep -Fx "$head" >/dev/null && return 0

--- a/gh-tidy
+++ b/gh-tidy
@@ -12,12 +12,13 @@ Tidies your work space!
     * Runs 'git gc' to clean up unnecessary files & optimize your local repo
     * Checks your local branches for ones that show as merged to master, and asks for your permission to delete them
     * Checks your local branches for ones that have their corresponding pull requests merged, and asks for your permission to delete them
+    * Checks for worktrees locked by another program whose directory no longer exists, and asks for your permission to unlock & remove them
 
 Options:
     --rebase-all
 	Rebases all your local branches to the latest master.
     --auto-delete-merged
-	Automatically delete merged branches without prompting (for non-interactive use, e.g. cron, CI, post-merge hooks).
+	Automatically delete merged branches and stale locked worktrees without prompting (for non-interactive use, e.g. cron, CI, post-merge hooks).
     --skip-gc
 	Skips the 'git gc' step (which executes by default)
     --skip-prune
@@ -29,7 +30,7 @@ Options:
 
 Environment Variables:
     GH_TIDY_REBASE_ALL         Set to 'true' to rebase all branches (same as --rebase-all)
-    GH_TIDY_AUTO_DELETE_MERGED Set to 'true' to auto-delete merged branches (same as --auto-delete-merged)
+    GH_TIDY_AUTO_DELETE_MERGED Set to 'true' to auto-delete merged branches & stale locked worktrees (same as --auto-delete-merged)
     GH_TIDY_SKIP_GC            Set to 'true' to skip git gc (same as --skip-gc)
     GH_TIDY_SKIP_PRUNE         Set to 'true' to skip git fetch --prune (same as --skip-prune)
     GH_TIDY_SKIP_UPDATE_CHECK  Set to 'true' to skip update check (same as --skip-update-check)
@@ -239,6 +240,40 @@ function get_worktree_branches() {
         found_first_separator && /^branch / { sub("^branch refs/heads/", ""); print }
       '
 }
+
+# A worktree locked by another program (IDE, editor, backup/sync tool) is excluded
+# from 'git worktree prune', so once its directory is gone it lingers forever and
+# keeps its branch un-deletable.  List those so we can offer to unlock & remove them.
+function get_stale_locked_worktrees() {
+  git worktree list --porcelain 2>/dev/null \
+    | awk '
+        /^worktree / { path = substr($0, 10); locked = 0 }
+        /^locked/    { locked = 1 }
+        /^$/         { if (locked) print path; path = ""; locked = 0 }
+        END          { if (locked) print path }
+      '
+}
+
+echo
+cyan "Checking for stale worktrees locked by another program..."
+while IFS= read -r worktree_path; do
+    [[ -n "$worktree_path" ]] || continue
+    if [[ -d "$worktree_path" ]]; then
+        # ponytail: a locked worktree whose directory still exists is presumed in use.
+        green "Skipping locked worktree '$worktree_path' (directory still exists)."
+        continue
+    fi
+    if ! "$AUTO_DELETE_MERGED"; then
+        read -p $'\e[93m'"Worktree ${worktree_path} is locked but its directory is gone - remove it? (y/n) "$'\e[0m' -n 1 -r
+        echo
+        [[ $REPLY =~ ^[Yy]$ ]] || continue
+    else
+        yellow "Auto-removing stale locked worktree '${worktree_path}'"
+    fi
+    git worktree unlock "$worktree_path" || true
+    git worktree remove --force "$worktree_path" || true
+done < <(get_stale_locked_worktrees)
+green "Complete!"
 
 worktree_branches=$(get_worktree_branches)
 

--- a/gh-tidy
+++ b/gh-tidy
@@ -13,6 +13,7 @@ Tidies your work space!
     * Checks your local branches for ones that show as merged to master, and asks for your permission to delete them
     * Checks your local branches for ones that have their corresponding pull requests merged, and asks for your permission to delete them
     * Safely removes clean worktrees whose HEAD has landed, along with their branches
+    * Prunes worktrees whose directories are gone, and asks about locked ones that pruning can't reach
 
 Options:
     --rebase-all
@@ -330,6 +331,11 @@ function delete_landed_branch() {
 
 echo
 cyan "Checking for worktrees whose work has already landed..."
+# Clear the administrative files left behind by worktrees whose directories are
+# gone.  This skips locked worktrees by design, which is why the loop below still
+# has to handle a missing directory itself.  Not gated on --skip-prune: that flag
+# is about the 'git fetch --prune' network round-trip, and this is purely local.
+git worktree prune -v
 # Fed on fd 3, not stdin: a plain '< <(...)' would make the worktree list the loop's
 # stdin, so the 'read -p' prompt below would silently eat list entries instead of
 # asking the user.

--- a/gh-tidy
+++ b/gh-tidy
@@ -255,7 +255,10 @@ function get_stale_locked_worktrees() {
       '
 }
 
-function worktree_head_is_merged() {
+# Has this commit landed on the trunk?  Returns 0 yes, 1 no, 2 couldn't tell.
+# The GitHub lookup is by head commit, not branch name or author, so it also sees
+# squash merges and pull requests opened by someone other than you.
+function head_is_merged() {
     local head="$1"
     git merge-base --is-ancestor "$head" "$trunk_branch" && return 0
     local merged_heads
@@ -322,7 +325,7 @@ while IFS=$'\t' read -r -u 3 worktree_path worktree_branch; do
             yellow "Keeping locked worktree '$worktree_path' (dirty)."
             continue
         fi
-        if worktree_head_is_merged "$worktree_head"; then
+        if head_is_merged "$worktree_head"; then
             :
         elif [[ $? -eq 2 ]]; then
             yellow "Keeping locked worktree '$worktree_path' (GitHub lookup failed; HEAD is unverifiable)."
@@ -380,6 +383,7 @@ function can_delete_branch() {
 echo
 cyan "Pruning local branches that show as 'merged' to local $trunk_branch..."
 for branch in $(git branch --merged "$trunk_branch" --format='%(refname:short)'); do
+    [[ "$branch" != "$trunk_branch" ]] || continue
     if can_delete_branch "$branch"; then
         if "$AUTO_DELETE_MERGED"; then
             yellow "Auto-deleting branch '${branch}' (merged into $trunk_branch)"
@@ -390,31 +394,39 @@ for branch in $(git branch --merged "$trunk_branch" --format='%(refname:short)')
             fi
         fi
     else
-        green "Skipping deletion of branch '$branch'."
+        green "Skipping branch '$branch' (checked out in a worktree)."
     fi
 done
 green "Complete!"
 # TODO Message if none found
 
-# Covers branches that get squashed & merged
+# Covers branches that get squashed & merged.  Matching on the head commit rather
+# than on 'gh pr list --author @me' also catches branches off pull requests you did
+# not author - a review/* or integrate/* branch lands as someone else's squash
+# commit, so the author filter and 'git branch --merged' above both miss it.
 echo
-cyan "Pruning YOUR local branches that have had their pull requests merged on Github..."
+cyan "Pruning local branches that have had their pull requests merged on Github..."
 for branch in $(git branch --format='%(refname:short)'); do
-    # TODO Make this work with collaborative branches where you aren't the author
-    if can_delete_branch "$branch"; then
-        merged_branch=$(gh pr list --author @me --state merged --limit 1 --search "head:$branch" --json headRefName --jq '.[].headRefName')
-        if [ -n "${merged_branch}" ] && [ "${merged_branch}" == "${branch}" ]; then
-            if "$AUTO_DELETE_MERGED"; then
-                yellow "Auto-deleting branch '${merged_branch}' (PR merged on GitHub)"
-                git branch -D "${merged_branch}" || true
-            else
-                if confirm "Branch ${merged_branch} has been merged - delete it?"; then
-                    git branch -D "${merged_branch}" || true
-                fi
-            fi
-        fi
+    [[ "$branch" != "$trunk_branch" ]] || continue
+    if ! can_delete_branch "$branch"; then
+        green "Skipping branch '$branch' (checked out in a worktree)."
+        continue
+    fi
+    branch_head=$(git rev-parse --verify "$branch" 2>/dev/null) || continue
+    head_is_merged "$branch_head" && merge_check=0 || merge_check=$?
+    if [[ $merge_check -eq 2 ]]; then
+        yellow "Skipping branch '$branch' (GitHub lookup failed; cannot confirm it landed)."
+        continue
+    elif [[ $merge_check -ne 0 ]]; then
+        continue
+    fi
+    if "$AUTO_DELETE_MERGED"; then
+        yellow "Auto-deleting branch '${branch}' (PR merged on GitHub)"
+        git branch -D "${branch}" || true
     else
-        green "Skipping deletion of branch '$branch'."
+        if confirm "Branch ${branch} has been merged - delete it?"; then
+            git branch -D "${branch}" || true
+        fi
     fi
 done
 green "Complete!"

--- a/gh-tidy
+++ b/gh-tidy
@@ -12,13 +12,13 @@ Tidies your work space!
     * Runs 'git gc' to clean up unnecessary files & optimize your local repo
     * Checks your local branches for ones that show as merged to master, and asks for your permission to delete them
     * Checks your local branches for ones that have their corresponding pull requests merged, and asks for your permission to delete them
-    * Safely removes eligible clean, landed locked worktrees and interactively handles missing ones
+    * Safely removes clean worktrees whose HEAD has landed, along with their branches
 
 Options:
     --rebase-all
 	Rebases all your local branches to the latest master.
     --auto-delete-merged
-	Automatically delete merged branches and stale locked worktrees without prompting (for non-interactive use, e.g. cron, CI, post-merge hooks).
+	Automatically delete merged branches and landed worktrees without prompting (for non-interactive use, e.g. cron, CI, post-merge hooks).
     --skip-gc
 	Skips the 'git gc' step (which executes by default)
     --skip-prune
@@ -30,7 +30,7 @@ Options:
 
 Environment Variables:
     GH_TIDY_REBASE_ALL         Set to 'true' to rebase all branches (same as --rebase-all)
-    GH_TIDY_AUTO_DELETE_MERGED Set to 'true' to auto-delete merged branches & stale locked worktrees (same as --auto-delete-merged)
+    GH_TIDY_AUTO_DELETE_MERGED Set to 'true' to auto-delete merged branches & landed worktrees (same as --auto-delete-merged)
     GH_TIDY_SKIP_GC            Set to 'true' to skip git gc (same as --skip-gc)
     GH_TIDY_SKIP_PRUNE         Set to 'true' to skip git fetch --prune (same as --skip-prune)
     GH_TIDY_SKIP_UPDATE_CHECK  Set to 'true' to skip update check (same as --skip-update-check)
@@ -241,17 +241,24 @@ function get_worktree_branches() {
       '
 }
 
-# A worktree locked by another program (IDE, editor, backup/sync tool) is excluded
-# from 'git worktree prune', so once its directory is gone it lingers forever and
-# keeps its branch un-deletable.  Emit "<path>TAB<branch>" for each of those.
-function get_stale_locked_worktrees() {
+# Every worktree except the main one, as "<path>TAB<branch>TAB<locked>".  A worktree
+# holds its branch hostage - git refuses to delete a checked-out branch - so a
+# worktree whose work has landed keeps a dead branch alive indefinitely.  Locked
+# ones are worse still: a lock (set by an IDE, editor, or backup/sync tool) also
+# excludes them from 'git worktree prune', so they linger even once their directory
+# is gone.  Each entry is only ever removed after proving it clean and landed.
+function get_prunable_worktrees() {
   git worktree list --porcelain 2>/dev/null \
     | awk -v OFS='\t' '
-        /^worktree / { path = substr($0, 10); branch = ""; locked = 0 }
+        # The first record is the main worktree, which is never prunable.
+        function flush() {
+            if (path != "" && ++seen > 1) print path, branch, locked
+            path = ""; branch = ""; locked = 0
+        }
+        /^worktree / { flush(); path = substr($0, 10) }
         /^branch /   { branch = substr($0, 8); sub("^refs/heads/", "", branch) }
         /^locked/    { locked = 1 }
-        /^$/         { if (locked) print path, branch; path = ""; branch = ""; locked = 0 }
-        END          { if (locked) print path, branch }
+        END          { flush() }
       '
 }
 
@@ -269,18 +276,24 @@ function head_is_merged() {
     return 1
 }
 
-function remove_locked_worktree() {
-    local path="$1"
-    if ! git worktree unlock "$path"; then
+# Unlocking is only valid for a worktree that is actually locked, and a failed
+# removal must leave the lock exactly as it found it.
+function remove_worktree() {
+    local path="$1" locked="$2"
+    if [[ "$locked" == "1" ]] && ! git worktree unlock "$path"; then
         red "Unable to unlock locked worktree '$path'."
         return 1
     fi
     if git worktree remove "$path"; then
-        green "Removed locked worktree '$path'."
+        green "Removed worktree '$path'."
         return 0
     fi
-    red "Unable to remove locked worktree '$path'; restoring its lock."
-    git worktree lock "$path" || red "Unable to restore lock for '$path'."
+    if [[ "$locked" == "1" ]]; then
+        red "Unable to remove worktree '$path'; restoring its lock."
+        git worktree lock "$path" || red "Unable to restore lock for '$path'."
+    else
+        red "Unable to remove worktree '$path'."
+    fi
     return 1
 }
 
@@ -316,49 +329,53 @@ function delete_landed_branch() {
 }
 
 echo
-cyan "Checking for stale worktrees locked by another program..."
+cyan "Checking for worktrees whose work has already landed..."
 # Fed on fd 3, not stdin: a plain '< <(...)' would make the worktree list the loop's
 # stdin, so the 'read -p' prompt below would silently eat list entries instead of
 # asking the user.
-while IFS=$'\t' read -r -u 3 worktree_path worktree_branch; do
+while IFS=$'\t' read -r -u 3 worktree_path worktree_branch worktree_locked; do
     [[ -n "$worktree_path" ]] || continue
     if [[ -d "$worktree_path" ]]; then
         if [[ -z "$worktree_branch" ]]; then
-            yellow "Keeping locked worktree '$worktree_path' (no branch checked out)."
+            yellow "Keeping worktree '$worktree_path' (no branch checked out)."
             continue
         fi
         if ! worktree_branch=$(git -C "$worktree_path" symbolic-ref --quiet --short HEAD); then
-            yellow "Keeping locked worktree '$worktree_path' (detached or unverifiable branch)."
+            yellow "Keeping worktree '$worktree_path' (detached or unverifiable branch)."
             continue
         fi
         if ! worktree_head=$(git -C "$worktree_path" rev-parse --verify HEAD 2>/dev/null); then
-            yellow "Keeping locked worktree '$worktree_path' (unverifiable HEAD)."
+            yellow "Keeping worktree '$worktree_path' (unverifiable HEAD)."
             continue
         fi
         if ! worktree_status=$(git -C "$worktree_path" status --porcelain --untracked-files=all 2>/dev/null); then
-            yellow "Keeping locked worktree '$worktree_path' (unable to inspect status)."
+            yellow "Keeping worktree '$worktree_path' (unable to inspect status)."
             continue
         elif [[ -n "$worktree_status" ]]; then
-            yellow "Keeping locked worktree '$worktree_path' (dirty)."
+            yellow "Keeping worktree '$worktree_path' (dirty)."
             continue
         fi
         if head_is_merged "$worktree_head"; then
             :
         elif [[ $? -eq 2 ]]; then
-            yellow "Keeping locked worktree '$worktree_path' (GitHub lookup failed; HEAD is unverifiable)."
+            yellow "Keeping worktree '$worktree_path' (GitHub lookup failed; HEAD is unverifiable)."
             continue
         else
-            yellow "Keeping locked worktree '$worktree_path' (HEAD is not landed)."
+            yellow "Keeping worktree '$worktree_path' (HEAD is not landed)."
             continue
         fi
         if "$AUTO_DELETE_MERGED"; then
-            yellow "Auto-removing locked worktree '$worktree_path' (clean, landed HEAD)"
-            { remove_locked_worktree "$worktree_path" && delete_landed_branch "$worktree_branch"; } || true
-        elif confirm "Locked worktree ${worktree_path} is clean with a landed HEAD - remove it?"; then
-            { remove_locked_worktree "$worktree_path" && delete_landed_branch "$worktree_branch"; } || true
+            yellow "Auto-removing worktree '$worktree_path' (clean, landed HEAD)"
+            { remove_worktree "$worktree_path" "$worktree_locked" && delete_landed_branch "$worktree_branch"; } || true
+        elif confirm "Worktree ${worktree_path} is clean with a landed HEAD - remove it?"; then
+            { remove_worktree "$worktree_path" "$worktree_locked" && delete_landed_branch "$worktree_branch"; } || true
         fi
         continue
     fi
+    # An unlocked worktree with no directory is already handled by 'git worktree
+    # prune'; only a locked one lingers, and it needs an explicit decision because
+    # its contents can no longer be inspected.
+    [[ "$worktree_locked" == "1" ]] || continue
     if "$AUTO_DELETE_MERGED"; then
         yellow "Skipping locked worktree '$worktree_path' (directory is gone; contents cannot be inspected)."
         continue
@@ -371,8 +388,8 @@ while IFS=$'\t' read -r -u 3 worktree_path worktree_branch; do
     if ! confirm "Worktree ${worktree_path} is locked but its directory is gone (${merge_status}) - remove it?"; then
         continue
     fi
-    remove_locked_worktree "$worktree_path" || true
-done 3< <(get_stale_locked_worktrees)
+    remove_worktree "$worktree_path" "$worktree_locked" || true
+done 3< <(get_prunable_worktrees)
 green "Complete!"
 
 worktree_branches=$(get_worktree_branches)

--- a/gh-tidy
+++ b/gh-tidy
@@ -12,7 +12,7 @@ Tidies your work space!
     * Runs 'git gc' to clean up unnecessary files & optimize your local repo
     * Checks your local branches for ones that show as merged to master, and asks for your permission to delete them
     * Checks your local branches for ones that have their corresponding pull requests merged, and asks for your permission to delete them
-    * Checks for worktrees locked by another program whose directory no longer exists, and asks for your permission to unlock & remove them
+    * Safely removes eligible clean, landed locked worktrees and interactively handles missing ones
 
 Options:
     --rebase-all
@@ -258,7 +258,12 @@ function get_stale_locked_worktrees() {
 function worktree_head_is_merged() {
     local head="$1"
     git merge-base --is-ancestor "$head" "$trunk_branch" && return 0
-    [[ -n "$(gh api --paginate "repos/{owner}/{repo}/commits/$head/pulls" --jq ".[] | select(.merged_at != null and .head.sha == \"$head\") | .head.sha" 2>/dev/null | grep -Fx "$head")" ]]
+    local merged_heads
+    if ! merged_heads=$(gh api --paginate "repos/{owner}/{repo}/commits/$head/pulls" --jq ".[] | select(.merged_at != null and .head.sha == \"$head\") | .head.sha" 2>/dev/null); then
+        return 2
+    fi
+    printf '%s\n' "$merged_heads" | grep -Fx "$head" >/dev/null && return 0
+    return 1
 }
 
 function remove_locked_worktree() {
@@ -317,7 +322,12 @@ while IFS=$'\t' read -r -u 3 worktree_path worktree_branch; do
             yellow "Keeping locked worktree '$worktree_path' (dirty)."
             continue
         fi
-        if ! worktree_head_is_merged "$worktree_head"; then
+        if worktree_head_is_merged "$worktree_head"; then
+            :
+        elif [[ $? -eq 2 ]]; then
+            yellow "Keeping locked worktree '$worktree_path' (GitHub lookup failed; HEAD is unverifiable)."
+            continue
+        else
             yellow "Keeping locked worktree '$worktree_path' (HEAD is not landed)."
             continue
         fi

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -102,6 +102,9 @@ export -f gh
 output=$(run_tidy "$repo")
 unset -f gh
 assert_missing "$worktree"
+# The worktree pass proved this head landed - the branch must go with it, since it
+# is squash-merged (not an ancestor of main) and so invisible to 'git branch --merged'.
+assert_no_branch "$repo" review/pr-73
 
 # A squash-merged branch with no worktree at all: only the head-commit lookup finds
 # it.  Nothing here is an ancestor of main, and the branch is not authored by @me.

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -62,21 +62,22 @@ assert_contains "$output" "not landed"
 repo="$tmp/older-pr"
 worktree="$tmp/older-pr-worktree"
 make_repo "$repo"
-add_locked_worktree "$repo" "$worktree" topic
+add_locked_worktree "$repo" "$worktree" review/pr-73
 touch "$worktree/older-pr"
 git -C "$worktree" add older-pr
 git -C "$worktree" commit -qm older-pr
 GH_TIDY_TEST_MATCH_HEAD=$(git -C "$worktree" rev-parse HEAD)
 gh() {
-  local limit=30 previous=
+  local limit=30 previous= search=
   for arg in "$@"; do
     [[ "$previous" == --limit ]] && limit=$arg
+    [[ "$previous" == --search ]] && search=$arg
     previous=$arg
   done
   for ((i = 0; i < limit; i++)); do
     echo 0000000000000000000000000000000000000000
   done
-  if (( limit > 100 )); then
+  if [[ "$search" == "$GH_TIDY_TEST_MATCH_HEAD" ]]; then
     echo "$GH_TIDY_TEST_MATCH_HEAD"
   fi
   return 0

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -168,6 +168,18 @@ output=$(run_tidy "$repo")
 assert_contains "$(git -C "$repo" worktree list --porcelain)" "locked test"
 assert_contains "$output" "directory is gone"
 
+# Unlocked and its directory is gone: 'git worktree prune' reaps it outright, so it
+# never reaches the loop and the user is never asked about it.
+repo="$tmp/missing-unlocked"
+worktree="$tmp/missing-unlocked-worktree"
+make_repo "$repo"
+add_worktree "$repo" "$worktree" topic
+rm -rf "$worktree"
+output=$(run_tidy "$repo")
+[[ "$(git -C "$repo" worktree list --porcelain)" != *"missing-unlocked-worktree"* ]] \
+  || fail "expected pruning to drop the stale worktree record"
+[[ "$output" != *"directory is gone"* ]] || fail "should not have prompted about a prunable worktree"
+
 repo="$tmp/remove-failure"
 worktree="$tmp/remove-failure-worktree"
 submodule="$tmp/submodule"

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'chmod -R u+w "$tmp" 2>/dev/null || true; rm -rf "$tmp"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+assert_exists() { [[ -d "$1" ]] || fail "expected $1 to exist"; }
+assert_missing() { [[ ! -e "$1" ]] || fail "expected $1 to be removed"; }
+assert_contains() { [[ "$1" == *"$2"* ]] || fail "expected output to contain: $2"; }
+
+make_repo() {
+  local repo="$1"
+  git init -q -b main "$repo"
+  git -C "$repo" config user.name test
+  git -C "$repo" config user.email test@example.com
+  touch "$repo/README"
+  git -C "$repo" add README
+  git -C "$repo" commit -qm initial
+}
+
+add_locked_worktree() {
+  local repo="$1" path="$2" branch="$3"
+  git -C "$repo" worktree add -q -b "$branch" "$path"
+  git -C "$repo" worktree lock --reason test "$path"
+}
+
+run_tidy() {
+  local repo="$1"
+  (cd "$repo" && GH_TIDY_DEV_MODE=true "$script_dir/gh-tidy" \
+    --auto-delete-merged --skip-gc --skip-prune --skip-update-check --trunk main) 2>&1
+}
+
+repo="$tmp/clean"
+worktree="$tmp/clean-landed"
+make_repo "$repo"
+add_locked_worktree "$repo" "$worktree" topic
+output=$(run_tidy "$repo")
+assert_missing "$worktree"
+
+repo="$tmp/dirty"
+worktree="$tmp/dirty-landed"
+make_repo "$repo"
+add_locked_worktree "$repo" "$worktree" topic
+touch "$worktree/dirty"
+output=$(run_tidy "$repo")
+assert_exists "$worktree"
+assert_contains "$output" "dirty"
+
+repo="$tmp/unlanded"
+worktree="$tmp/unlanded-worktree"
+make_repo "$repo"
+add_locked_worktree "$repo" "$worktree" topic
+touch "$worktree/unlanded"
+git -C "$worktree" add unlanded
+git -C "$worktree" commit -qm unlanded
+output=$(run_tidy "$repo")
+assert_exists "$worktree"
+assert_contains "$output" "not landed"
+
+repo="$tmp/missing"
+worktree="$tmp/missing-worktree"
+make_repo "$repo"
+add_locked_worktree "$repo" "$worktree" topic
+rm -rf "$worktree"
+output=$(run_tidy "$repo")
+assert_contains "$(git -C "$repo" worktree list --porcelain)" "locked test"
+assert_contains "$output" "directory is gone"
+
+repo="$tmp/remove-failure"
+worktree="$tmp/remove-failure-worktree"
+submodule="$tmp/submodule"
+git init -q -b main "$submodule"
+git -C "$submodule" config user.name test
+git -C "$submodule" config user.email test@example.com
+touch "$submodule/README"
+git -C "$submodule" add README
+git -C "$submodule" commit -qm initial
+make_repo "$repo"
+git -C "$repo" -c protocol.file.allow=always submodule add -q "$submodule" vendor/submodule
+git -C "$repo" commit -qm 'add submodule'
+add_locked_worktree "$repo" "$worktree" topic
+git -C "$worktree" -c protocol.file.allow=always submodule update --init -q
+output=$(run_tidy "$repo" || true)
+assert_contains "$(git -C "$repo" worktree list --porcelain)" "locked"
+assert_contains "$output" "Unable to remove locked worktree"
+
+echo "PASS: locked worktree cleanup"

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -68,16 +68,8 @@ git -C "$worktree" add older-pr
 git -C "$worktree" commit -qm older-pr
 GH_TIDY_TEST_MATCH_HEAD=$(git -C "$worktree" rev-parse HEAD)
 gh() {
-  local limit=30 previous= search=
-  for arg in "$@"; do
-    [[ "$previous" == --limit ]] && limit=$arg
-    [[ "$previous" == --search ]] && search=$arg
-    previous=$arg
-  done
-  for ((i = 0; i < limit; i++)); do
+  if [[ "$1" == api && "$3" == "repos/{owner}/{repo}/commits/$GH_TIDY_TEST_MATCH_HEAD/pulls" ]]; then
     echo 0000000000000000000000000000000000000000
-  done
-  if [[ "$search" == "$GH_TIDY_TEST_MATCH_HEAD" ]]; then
     echo "$GH_TIDY_TEST_MATCH_HEAD"
   fi
   return 0

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -55,9 +55,26 @@ add_locked_worktree "$repo" "$worktree" topic
 touch "$worktree/unlanded"
 git -C "$worktree" add unlanded
 git -C "$worktree" commit -qm unlanded
+gh() { return 0; }
+export -f gh
 output=$(run_tidy "$repo")
+unset -f gh
 assert_exists "$worktree"
 assert_contains "$output" "not landed"
+
+repo="$tmp/lookup-failure"
+worktree="$tmp/lookup-failure-worktree"
+make_repo "$repo"
+add_locked_worktree "$repo" "$worktree" topic
+touch "$worktree/unlanded"
+git -C "$worktree" add unlanded
+git -C "$worktree" commit -qm unlanded
+gh() { return 1; }
+export -f gh
+output=$(run_tidy "$repo")
+unset -f gh
+assert_exists "$worktree"
+assert_contains "$output" "lookup failed"
 
 repo="$tmp/older-pr"
 worktree="$tmp/older-pr-worktree"

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -9,6 +9,12 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 assert_exists() { [[ -d "$1" ]] || fail "expected $1 to exist"; }
 assert_missing() { [[ ! -e "$1" ]] || fail "expected $1 to be removed"; }
 assert_contains() { [[ "$1" == *"$2"* ]] || fail "expected output to contain: $2"; }
+assert_no_branch() {
+  git -C "$1" show-ref --verify --quiet "refs/heads/$2" && fail "expected branch $2 to be deleted" || true
+}
+assert_branch() {
+  git -C "$1" show-ref --verify --quiet "refs/heads/$2" || fail "expected branch $2 to survive"
+}
 
 make_repo() {
   local repo="$1"
@@ -96,6 +102,34 @@ export -f gh
 output=$(run_tidy "$repo")
 unset -f gh
 assert_missing "$worktree"
+
+# A squash-merged branch with no worktree at all: only the head-commit lookup finds
+# it.  Nothing here is an ancestor of main, and the branch is not authored by @me.
+repo="$tmp/squashed-no-worktree"
+make_repo "$repo"
+git -C "$repo" branch review/pr-80
+git -C "$repo" branch keep/unlanded
+for b in review/pr-80 keep/unlanded; do
+  git -C "$repo" checkout -q "$b"
+  touch "$repo/${b//\//-}-file"
+  git -C "$repo" add -A
+  git -C "$repo" commit -qm "$b"
+done
+git -C "$repo" checkout -q main
+GH_TIDY_TEST_MATCH_HEAD=$(git -C "$repo" rev-parse review/pr-80)
+gh() {
+  if [[ "$1" == api && "$3" == "repos/{owner}/{repo}/commits/$GH_TIDY_TEST_MATCH_HEAD/pulls" ]]; then
+    echo "$GH_TIDY_TEST_MATCH_HEAD"
+  fi
+  return 0
+}
+export GH_TIDY_TEST_MATCH_HEAD
+export -f gh
+output=$(run_tidy "$repo")
+unset -f gh
+assert_no_branch "$repo" review/pr-80
+assert_branch "$repo" keep/unlanded
+assert_branch "$repo" main
 
 repo="$tmp/missing"
 worktree="$tmp/missing-worktree"

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -26,10 +26,14 @@ make_repo() {
   git -C "$repo" commit -qm initial
 }
 
-add_locked_worktree() {
+add_worktree() {
   local repo="$1" path="$2" branch="$3"
   git -C "$repo" worktree add -q -b "$branch" "$path"
-  git -C "$repo" worktree lock --reason test "$path"
+}
+
+add_locked_worktree() {
+  add_worktree "$@"
+  git -C "$1" worktree lock --reason test "$2"
 }
 
 run_tidy() {
@@ -44,6 +48,27 @@ make_repo "$repo"
 add_locked_worktree "$repo" "$worktree" topic
 output=$(run_tidy "$repo")
 assert_missing "$worktree"
+
+# An unlocked worktree is swept on the same terms as a locked one - it holds its
+# branch hostage just as effectively.  The main worktree must survive regardless.
+repo="$tmp/unlocked"
+worktree="$tmp/unlocked-landed"
+make_repo "$repo"
+add_worktree "$repo" "$worktree" topic
+output=$(run_tidy "$repo")
+assert_missing "$worktree"
+assert_exists "$repo"
+assert_no_branch "$repo" topic
+assert_branch "$repo" main
+
+repo="$tmp/unlocked-dirty"
+worktree="$tmp/unlocked-dirty-worktree"
+make_repo "$repo"
+add_worktree "$repo" "$worktree" topic
+touch "$worktree/dirty"
+output=$(run_tidy "$repo")
+assert_exists "$worktree"
+assert_branch "$repo" topic
 
 repo="$tmp/dirty"
 worktree="$tmp/dirty-landed"
@@ -159,6 +184,6 @@ add_locked_worktree "$repo" "$worktree" topic
 git -C "$worktree" -c protocol.file.allow=always submodule update --init -q
 output=$(run_tidy "$repo" || true)
 assert_contains "$(git -C "$repo" worktree list --porcelain)" "locked"
-assert_contains "$output" "Unable to remove locked worktree"
+assert_contains "$output" "Unable to remove worktree"
 
 echo "PASS: locked worktree cleanup"

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -59,6 +59,34 @@ output=$(run_tidy "$repo")
 assert_exists "$worktree"
 assert_contains "$output" "not landed"
 
+repo="$tmp/older-pr"
+worktree="$tmp/older-pr-worktree"
+make_repo "$repo"
+add_locked_worktree "$repo" "$worktree" topic
+touch "$worktree/older-pr"
+git -C "$worktree" add older-pr
+git -C "$worktree" commit -qm older-pr
+GH_TIDY_TEST_MATCH_HEAD=$(git -C "$worktree" rev-parse HEAD)
+gh() {
+  local limit=30 previous=
+  for arg in "$@"; do
+    [[ "$previous" == --limit ]] && limit=$arg
+    previous=$arg
+  done
+  for ((i = 0; i < limit; i++)); do
+    echo 0000000000000000000000000000000000000000
+  done
+  if (( limit > 100 )); then
+    echo "$GH_TIDY_TEST_MATCH_HEAD"
+  fi
+  return 0
+}
+export GH_TIDY_TEST_MATCH_HEAD
+export -f gh
+output=$(run_tidy "$repo")
+unset -f gh
+assert_missing "$worktree"
+
 repo="$tmp/missing"
 worktree="$tmp/missing-worktree"
 make_repo "$repo"

--- a/tests/locked-worktree-cleanup.sh
+++ b/tests/locked-worktree-cleanup.sh
@@ -146,7 +146,10 @@ done
 git -C "$repo" checkout -q main
 GH_TIDY_TEST_MATCH_HEAD=$(git -C "$repo" rev-parse review/pr-80)
 gh() {
-  if [[ "$1" == api && "$3" == "repos/{owner}/{repo}/commits/$GH_TIDY_TEST_MATCH_HEAD/pulls" ]]; then
+  if [[ "$1 $2" == "repo view" ]]; then
+    echo github.example.com
+  elif [[ "$1" == api && "$2" == --hostname && "$3" == github.example.com \
+    && "$5" == "repos/{owner}/{repo}/commits/$GH_TIDY_TEST_MATCH_HEAD/pulls" ]]; then
     echo "$GH_TIDY_TEST_MATCH_HEAD"
   fi
   return 0


### PR DESCRIPTION
## Problem

Locked worktree records can outlive the work that created them. Git deliberately excludes locked worktrees from `git worktree prune`, so stale records keep branches checked out and prevent `gh tidy` from pruning those branches.

A directory existing is not enough to prove the worktree is still needed, while a missing directory is not enough to prove it is safe to remove automatically.

## Change

Adds conservative locked-worktree cleanup before branch pruning:

- Existing worktrees are eligible only when their status is clean and their exact HEAD has landed on trunk or is the head commit of a merged pull request.
- Dirty, detached, unlanded, or unverifiable worktrees are retained with a reason.
- Missing worktrees require interactive confirmation and are never removed by `--auto-delete-merged`.
- Removal unlocks the worktree and uses plain `git worktree remove`; failures are reported and the lock is restored.
- Pull request matching uses the exact commit-associated PR rather than branch names or author identity.
- Non-interactive prompts skip safely instead of aborting under `set -e`.

No new flags are added. `--auto-delete-merged` applies only to clean, landed worktrees whose directories can be inspected.

## Testing

- `bash tests/locked-worktree-cleanup.sh`
- `bash -n gh-tidy`
- `git diff --check`
- `./gh-tidy --help`

The integration test covers clean landed worktrees, dirty and unlanded worktrees, missing directories, exact merged-PR lookup, GitHub lookup failure, and removal failure with lock restoration.
